### PR TITLE
fix: pond-cli `pond key generate` and `pond tenant list` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "prometheus-client>=0.21.0",  # For metrics collection
     "prometheus-fastapi-instrumentator>=7.0.0",  # For automatic HTTP metrics
     "PyYAML>=6.0",  # For formatting health output in MCP server
+    "en-core-web-lg",
 ]
 
 [project.scripts]
@@ -68,6 +69,9 @@ dev = [
 
 [tool.uv]
 package = true
+
+[tool.uv.sources]
+en-core-web-lg = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pond"]

--- a/src/pond/config.py
+++ b/src/pond/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        extra="ignore",
     )
 
     # Database

--- a/src/pond/infrastructure/auth.py
+++ b/src/pond/infrastructure/auth.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import secrets
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pond.infrastructure.database import DatabasePool
 
@@ -46,7 +46,7 @@ class APIKeyManager:
                 """,
                 key_hash,
                 description
-                or f"API key created at {datetime.now(datetime.UTC).isoformat()}",
+                or f"API key created at {datetime.now(timezone.utc).isoformat()}",
             )
 
         return api_key

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -420,7 +420,7 @@ version = "3.22.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
 ]
@@ -489,6 +489,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967, upload-time = "2024-06-20T11:30:30.034Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631", size = 33521, upload-time = "2024-06-20T11:30:28.248Z" },
+]
+
+[[package]]
+name = "en-core-web-lg"
+version = "3.8.0"
+source = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl" }
+wheels = [
+    { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl", hash = "sha256:293e9547a655b25499198ab15a525b05b9407a75f10255e405e8c3854329ab63" },
 ]
 
 [[package]]
@@ -1269,13 +1277,14 @@ wheels = [
 
 [[package]]
 name = "pond"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "click" },
+    { name = "en-core-web-lg" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "greenlet" },
@@ -1320,6 +1329,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "click", specifier = ">=8.1.0" },
+    { name = "en-core-web-lg", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=1.0.0" },
     { name = "greenlet", specifier = ">=3.2.3" },


### PR DESCRIPTION
This fixes the `pond-cli` so that it will work without error on `pond key generate` and `pond tenant list` with extra env vars passed.
I also added the extra dependency needed `en-core-web-lg`. It seems the project needed this to start.

